### PR TITLE
Use bootstrap-sprockets instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
       env: "RAILS_VERSION=4.2.1"
     - rvm: 2.0
       env: "RAILS_VERSION=4.2.1"
-    - rvm: 1.9.3
-      env: "RAILS_VERSION=4.2.1"
 
 notifications:
   irc: "irc.freenode.org#projecthydra"

--- a/app/assets/javascripts/browse_everything.js
+++ b/app/assets/javascripts/browse_everything.js
@@ -1,4 +1,4 @@
 //= require jquery
 //= require jquery.treetable
-//= require bootstrap
+//= require bootstrap-sprockets
 //= require browse_everything/behavior


### PR DESCRIPTION
Using bootstrap concatenates all the files, and most external libraries
instead individually include each necessary piece of JS. If
browse-everything uses bootstrap without the "-sprockets", Bootstrap' JS
effectively gets included twice.