### PR TITLE
Optionally adding state to url so box and dropbox will work

### DIFF
--- a/app/controllers/browse_everything_controller.rb
+++ b/app/controllers/browse_everything_controller.rb
@@ -40,6 +40,7 @@ class BrowseEverythingController < ActionController::Base
     @auth_link ||= if provider.present?
       link, data = provider.auth_link
       session["#{provider_name}_data"] = data
+      link = "#{link}&state=#{provider.key}" unless link.include?("state")
       link
     else
       nil

--- a/spec/helper/browse_everything_controller_helper_spec.rb
+++ b/spec/helper/browse_everything_controller_helper_spec.rb
@@ -8,15 +8,30 @@ describe BrowseEverythingController, type: :controller do
 
   let(:helper_context) {controller.view_context}
   let(:browser) { BrowseEverything::Browser.new(url_options) }
-  let(:provider) { browser.providers['dropbox'] }
 
   before do
     allow(controller).to receive(:provider).and_return(provider)
   end
-  describe "auth_link" do
-    subject {helper_context.auth_link}
-    it "has a single state" do
-      expect(subject.scan(/state/).length).to eq 1
+
+  context 'dropbox' do
+    let(:provider) { browser.providers['dropbox'] }
+
+    describe "auth_link" do
+      subject {helper_context.auth_link}
+      it "has a single state" do
+        expect(subject.scan(/state/).length).to eq 1
+      end
+    end
+  end
+
+  context 'box' do
+    let(:provider) { browser.providers['box'] }
+
+    describe "auth_link" do
+      subject {helper_context.auth_link}
+      it "has a single state" do
+        expect(subject.scan(/state/).length).to eq 1
+      end
     end
   end
 end


### PR DESCRIPTION
During regression testing we noticed that although dropbox was now working box was not allowing connections.  This commit allows for one state to be added to the url, and adds a test to be certain there is a state for box and dropbox providers.