### PR TITLE
Don't wait for auto-toggle if the explicit browseEverything() call is seen first.

### DIFF
--- a/app/assets/javascripts/browse_everything/behavior.js.coffee
+++ b/app/assets/javascripts/browse_everything/behavior.js.coffee
@@ -183,6 +183,7 @@ $ ->
 
   $.fn.browseEverything = (options) ->
     ctx = $(this).data('context')
+    options = $(this).data() unless (ctx? or options?)
     if options?
       ctx = initialize(this[0], options)
       $(this).click () ->
@@ -302,7 +303,9 @@ $ ->
 
 auto_toggle = ->
   triggers = $('*[data-toggle=browse-everything]')
-  triggers.each () -> $(this).browseEverything($(this).data())
+  triggers.each () -> 
+    ctx = $(this).data('context')
+    $(this).browseEverything($(this).data()) unless ctx?
 
 if Turbolinks? && Turbolinks.supported
   # Use turbolinks:load for Turbolinks 5, otherwise use the old way


### PR DESCRIPTION
In certain situations, the `$(obj).browseEverything()` call might get triggered before the auto-toggled initialization caused by `<button data-toggle="browse-everything"... />`. If that happens, the promise object returned by the `browseEverything()` call gets wiped out later during auto-toggle initialization. This change does two things:

1. Causes manual init to include the auto-toggle parameters _if the target hasn't been initialized yet_.
2. Skips auto-toggle init _for any target that's already been manually initialized_.

IOW, whichever init happens first will handle the toggle parameters, and auto-toggle will only happen if it needs to.