### PR TITLE
Guard against cross-site scripting attacks

### DIFF
--- a/app/controllers/browse_everything_controller.rb
+++ b/app/controllers/browse_everything_controller.rb
@@ -4,6 +4,8 @@ class BrowseEverythingController < ActionController::Base
   layout 'browse_everything'
   helper BrowseEverythingHelper
 
+  protect_from_forgery with: :exception
+
   after_action { session["#{provider_name}_token"] = provider.token unless provider.nil? }
 
   def index


### PR DESCRIPTION
I'm not sure if this is entirely necessary, or even if it might break things. If your base application is already doing this, what happens if you include an engine that does as well?

Someone notified us that not including this was a security flaw, which is technically true I think, but only if you're using this gem alone and not within the context of another Rails application which (ostensively) would be guarding against these attacks.

Thoughts? @jkeck @jcoyne @jeremyf