### PR TITLE
Set size of container columns

### DIFF
--- a/app/assets/javascripts/browse_everything/behavior.js.coffee
+++ b/app/assets/javascripts/browse_everything/behavior.js.coffee
@@ -148,6 +148,7 @@ $ ->
     set_size = (selector, pct) ->
       $(selector, table).width(full_width * pct).css('width',full_width * pct).css('max-width',full_width * pct)
     set_size '.ev-file', 0.4
+    set_size '.ev-container', 0.4
     set_size '.ev-size', 0.1
     set_size '.ev-kind', 0.3
     set_size '.ev-date', 0.2

--- a/app/assets/stylesheets/browse_everything/_browse_everything.scss
+++ b/app/assets/stylesheets/browse_everything/_browse_everything.scss
@@ -16,17 +16,17 @@
   margin: 0 0 0 -37.5%;
   left: 50%;
   top: 10%;
-  background-color: initial; 
+  background-color: initial;
   width: 75%;
 
   div {
     background-color: white;
   }
-  
+
   .modal-header {
     padding: 8px;
   }
-  
+
   .modal-body {
     overflow: hidden;
   }
@@ -38,17 +38,16 @@
   .row {
     margin: inherit;
   }
-  
+
   .ev-files {
     position: relative;
     overflow-x: auto;
     overflow-y: auto;
 
-    li { 
+    li {
       overflow: hidden;
       text-overflow: ellipsis;
       .ev-file-name {
-  //      padding: 0px 6px;
         white-space: nowrap;
       }
       border-top: none;
@@ -105,12 +104,12 @@
       }
     }
   }
-  
+
   .ev-files {
     height: 50vh;
     li { @include ev-link; }
   }
-  
+
   .ev-providers {
     select { width: 30% }
   }

--- a/app/views/browse_everything/_file.html.erb
+++ b/app/views/browse_everything/_file.html.erb
@@ -1,25 +1,33 @@
-<% if file.container? || provider.config[:max_upload_file_size].blank? # never disable a folder or if no maximum is set
+<%# Never disable folders. Files are only disabled if their size exceeds the maximum %>
+<% if file.container? || provider.config[:max_upload_file_size].blank?
    disabled = false
  else
    max_size = provider.config[:max_upload_file_size].to_i
    disabled = file.size > max_size
  end
 %>
-<tr role="row" tabindex="-1" data-ev-location="<%= file.location %>" data-tt-id="<%=path%>" data-tt-parent-id="<%=parent%>" data-tt-branch="<%=file.container? ? 'true' : 'false'%>">
+<tr role="row" tabindex="-1"
+    data-ev-location="<%= file.location %>"
+    data-tt-id="<%=path%>"
+    data-tt-parent-id="<%=parent%>"
+    data-tt-branch="<%=file.container? ? 'true' : 'false'%>">
+
   <td role="gridcell" class="<%=file.container? ? 'ev-container' : 'ev-file'%> ev-file-name">
     <% if disabled %>
-      <span title="<%= t('browse_everything.size_disabled', max_size: number_to_human_size(max_size)) %>"class="<%=file.container? ? 'folder' : 'file'%>" aria-hidden="true">
-      <%= file.name %>
+      <span title="<%= t('browse_everything.size_disabled', max_size: number_to_human_size(max_size)) %>"
+            class="<%=file.container? ? 'folder' : 'file'%>" aria-hidden="true">
+        <%= file.name %>
       </span>
       <span class="sr-only"><%= file.container? ? ', folder' : ', file' %> </span>
     <% else %>
-      <%= link_to browse_everything_engine.contents_path(provider_name, file.id), :class=>'ev-link' do %>
+      <%= link_to browse_everything_engine.contents_path(provider_name, file.id), class: 'ev-link' do %>
         <span class="<%=file.container? ? 'folder' : 'file'%>" aria-hidden="true"/>
         <%= file.name %>
         <span class="sr-only"><%= file.container? ? ', folder' : ', file' %> </span>
       <% end %>
     <% end %>
   </td>
+
   <% if file.container? %>
     <td role="gridcell" class="ev-directory-select">
       <%= check_box_tag(:select_all, "0", false, class: "ev-select-all") %>
@@ -29,12 +37,15 @@
       <%= check_box_tag(file.id.to_s.parameterize, "0", false, class: "ev-select-file") %>
     </td>
   <% end %>
+
   <td role="gridcell" class="ev-file-size">
     <%= number_to_human_size(file.size).sub(/Bytes/,'bytes') %>
   </td>
+
   <td role="gridcell" class="ev-file-kind">
     <%= file.type %>
   </td>
+
   <td role="gridcell" class="ev-file-date">
     <%= file.mtime.strftime('%F %R') %>
   </td>


### PR DESCRIPTION
This allows directories with long names to properly truncate the same way as files.

Additionally, the scss and view code was cleaned up for better readability.