### PR TITLE
Add visual changes when waiting for provider responses

### DIFF
--- a/app/assets/javascripts/browse_everything/behavior.js.coffee
+++ b/app/assets/javascripts/browse_everything/behavior.js.coffee
@@ -118,8 +118,7 @@ $ ->
         table.treetable("unloadBranch", node)
       onNodeExpand: ->
         node = this
-        $('body').css('cursor','wait')
-        $("html").addClass("wait")
+        startWait()
         size = $(node.row).find('td.ev-file-size').text().trim()
         start = 1
         increment = 1
@@ -173,16 +172,27 @@ $ ->
         selectAll(rows)
     .always ->
         clearInterval progressIntervalID
-        $('body').css('cursor','default')
-        $("html").removeClass("wait")
+        stopWait()
 
   setProgress = (done)->
-    $('#loading_progress').css('width',done+'%')
-    $('#loading_progress').html(done+'% complete')
-    $('#loading_progress').attr('aria-valuenow', done)
+    $('.loading-text').text(done+'% complete')
 
   refreshFiles = ->
     $('.ev-providers select').change()
+
+  startWait = ->
+    $('.loading-progress').removeClass("hidden")
+    $('body').css('cursor','wait')
+    $("html").addClass("wait")
+    $(".ev-browser").addClass("loading")
+    $('.ev-submit').attr('disabled', true)
+
+  stopWait = ->
+    $('.loading-progress').addClass("hidden")
+    $('body').css('cursor','default')
+    $("html").removeClass("wait")
+    $(".ev-browser").removeClass("loading")
+    $('.ev-submit').attr('disabled', false)
 
   $(window).on('resize', -> sizeColumns($('table#file-list')))
 
@@ -224,7 +234,7 @@ $ ->
   $(document).on 'click', 'button.ev-submit', (event) ->
     event.preventDefault()
     $(this).button('loading')
-    $('body').css('cursor','wait')
+    startWait()
     main_form = $(this).closest('form')
     resolver_url = main_form.data('resolver')
     ctx = dialog.data('ev-state')
@@ -255,7 +265,7 @@ $ ->
 
   $(document).on 'change', '.ev-providers select', (event) ->
     event.preventDefault()
-    $('body').css('cursor','wait')
+    startWait()
     $.ajax
       url: $(this).val(),
       data:
@@ -272,7 +282,7 @@ $ ->
       else
         $('.ev-files').html(xhr.responseText)
     .always ->
-      $('body').css('cursor','default')
+      stopWait()
 
   $(document).on 'click', '.ev-providers a', (event) ->
     $('.ev-providers li').removeClass('ev-selected')

--- a/app/assets/stylesheets/browse_everything/_browse_everything.scss
+++ b/app/assets/stylesheets/browse_everything/_browse_everything.scss
@@ -98,4 +98,19 @@
     select { width: 30% }
   }
 
+  .loading {
+    pointer-events: none;
+    opacity: 0.2;
+  }
+
+  .loading-progress {
+    position: absolute;
+    top: 8em;
+    left: 4em;
+  }
+
+  // Massively large text instead of something more artistic
+  .loading-text {
+    font-size: 4em;
+  }
 }

--- a/app/views/browse_everything/_files.html.erb
+++ b/app/views/browse_everything/_files.html.erb
@@ -1,8 +1,3 @@
-  <div class="progress" id="loading_progress" aria-live="polite">
-    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 100%;">
-      100% Complete
-    </div>
-  </div>
   <table id="file-list" role="grid" tabindex="-1" title="Choose files to upload from the table below" aria-live="polite">
     <thead>
       <tr role="row" tabindex="-1">

--- a/app/views/browse_everything/index.html.erb
+++ b/app/views/browse_everything/index.html.erb
@@ -6,6 +6,9 @@
     </div>
   </div>
   <div class="modal-body ev-body" tabindex="-1">
+    <div class="loading-progress" aria-live="assertive">
+      <span class="loading-text">Loading...</span>
+    </div>
     <div class="ev-browser row<%=bs2('-fluid')%>" aria-live="polite">
       <div class="<%=fa3or4('fa3','fa4')%> <%=bs2or3('bs2 span','bs3 col-xs-')%>12 ev-files list">
         <%= render :partial => 'files' if provider.present? %>


### PR DESCRIPTION
Progress bar doesn't work within a modal, so this displays text with a faded background.

![loading](https://cloud.githubusercontent.com/assets/312085/24204040/a7608a10-0eed-11e7-8305-176464fdc4d0.png)
