### PR TITLE
Amazon S3 driver enhancements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ AllCops:
 Rails:
   Enabled: true
 
+Metrics/ClassLength:
+  Max: 130
+  
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
   Max: 400

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 This Gem allows your rails application to access user files from cloud storage.
 Currently there are drivers implemented for [Dropbox](http://www.dropbox.com),
 [Skydrive](https://skydrive.live.com/), [Google Drive](http://drive.google.com),
-[Box](http://www.box.com), and a server-side directory share.
+[Box](http://www.box.com), [Amazon S3](https://aws.amazon.com/s3/),
+and a server-side directory share.
 
 The gem uses [OAuth](http://oauth.net/) to connect to a user's account and
 generate a list of single use urls that your application can then use to

--- a/lib/browse_everything/browser.rb
+++ b/lib/browse_everything/browser.rb
@@ -16,7 +16,7 @@ module BrowseEverything
         begin
           driver_klass = BrowseEverything::Driver.const_get((config[:driver] || driver.to_s).camelize.to_sym)
           @providers[driver] = driver_klass.new(config.merge(url_options: url_options))
-        rescue
+        rescue NameError
           Rails.logger.warn "Unknown provider: #{driver}"
         end
       end

--- a/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
+++ b/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
@@ -12,11 +12,12 @@
 #   :client_id: YOUR_GOOGLE_API_CLIENT_ID
 #   :client_secret: YOUR_GOOGLE_API_CLIENT_SECRET
 # s3:
-#   :app_key: YOUR_AWS_S3_KEY
-#   :app_secret: YOUR_AWS_S3_SECRET
 #   :bucket: YOUR_AWS_S3_BUCKET
-#   :region: YOUR_AWS_S3_REGION # default: us-east-1
-#   :signed_url: true # set to false for public urls
+#   :response_type: :signed_url # set to :public_url for public urls or :s3_uri for an s3://BUCKET/KEY uri
+#   :app_key: YOUR_AWS_S3_KEY       # :app_key, :app_secret, and :region can be specified
+#   :app_secret: YOUR_AWS_S3_SECRET # explicitly here, or left out to use system-configured
+#   :region: YOUR_AWS_S3_REGION     # defaults.
+#   See https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/
 # sky_drive:
 #   :client_id: YOUR_MS_LIVE_CONNECT_CLIENT_ID
 #   :client_secret: YOUR_MS_LIVE_CONNECT_CLIENT_SECRET


### PR DESCRIPTION
Changes in this commit:

* Adheres to the conventions for AWS' [cross-SDK configuration defaults](https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/).
* Adds an `:s3_uri` output format (`s3://bucket_name/path/to/file`) in addition to public and signed URLs.
* Deprecates the `:signed_url` config option in favor of `:response_type` to accommodate the S3 URI option.
